### PR TITLE
Update for latest WiringPi version

### DIFF
--- a/RaspberryPiTransmitPin.cpp
+++ b/RaspberryPiTransmitPin.cpp
@@ -23,7 +23,7 @@ RaspberryPiTransmitPin::RaspberryPiTransmitPin(const int nTransmitPin) {
 void RaspberryPiTransmitPin::init(const int nTransmitPin, const int nNonRealtimeOffset) {
     printf("RPi Transmit Pin: %d with offset: %d\n", nTransmitPin, nNonRealtimeOffset);
     wiringPiSetupSys();
-    this->nTransmitterPin = nTransmitterPin;
+    this->nTransmitterPin = nTransmitPin;
     this->nNonRealtimeOffset = nNonRealtimeOffset;
 }
 

--- a/RaspberryPiTransmitPin.cpp
+++ b/RaspberryPiTransmitPin.cpp
@@ -22,6 +22,7 @@ RaspberryPiTransmitPin::RaspberryPiTransmitPin(const int nTransmitPin) {
 
 void RaspberryPiTransmitPin::init(const int nTransmitPin, const int nNonRealtimeOffset) {
     printf("RPi Transmit Pin: %d with offset: %d\n", nTransmitPin, nNonRealtimeOffset);
+    wiringPiSetupSys();
     this->nTransmitterPin = nTransmitterPin;
     this->nNonRealtimeOffset = nNonRealtimeOffset;
     this->enableTransmit(); 
@@ -29,10 +30,6 @@ void RaspberryPiTransmitPin::init(const int nTransmitPin, const int nNonRealtime
 
 RaspberryPiTransmitPin::~RaspberryPiTransmitPin() {
 
-}
-
-int RaspberryPiTransmitPin::initialize() {
-    return (wiringPiSetup() != 1);
 }
 
 void RaspberryPiTransmitPin::enableTransmit() {

--- a/RaspberryPiTransmitPin.cpp
+++ b/RaspberryPiTransmitPin.cpp
@@ -25,15 +25,9 @@ void RaspberryPiTransmitPin::init(const int nTransmitPin, const int nNonRealtime
     wiringPiSetupSys();
     this->nTransmitterPin = nTransmitterPin;
     this->nNonRealtimeOffset = nNonRealtimeOffset;
-    this->enableTransmit(); 
 }
 
 RaspberryPiTransmitPin::~RaspberryPiTransmitPin() {
-
-}
-
-void RaspberryPiTransmitPin::enableTransmit() {
-    pinMode(this->nTransmitterPin, OUTPUT);
 }
 
 void RaspberryPiTransmitPin::setPinLevel(const int nLevel) {

--- a/RaspberryPiTransmitPin.h
+++ b/RaspberryPiTransmitPin.h
@@ -16,7 +16,6 @@ public:
 	RaspberryPiTransmitPin(const int nTransmitPin, const int nNonRealtimeOffset);
 	virtual ~RaspberryPiTransmitPin();
 
-    int initialize();
     void pullPinLowForPeriodSync(const unsigned int nPulseLength);
     void pullPinHighForPeriodSync(const unsigned int nPulseLength);
 

--- a/RaspberryPiTransmitPin.h
+++ b/RaspberryPiTransmitPin.h
@@ -21,7 +21,6 @@ public:
 
 private:
     void init(const int nTransmitPin, const int nNonRealtimeOffset);
-    void enableTransmit();
     void setPinLevel(const int nLevel);
     void pullPinToLevelForPeriodSync(const int nLevel, const unsigned int nPulseLength);
 

--- a/TransmitPinFactory.cpp
+++ b/TransmitPinFactory.cpp
@@ -18,12 +18,6 @@ TransmitPin* TransmitPinFactory::create(int nTransmitPin, int nNonRealtimeOffset
     printf("Constructing RaspberryPi TransmitPin\n");
 
     RaspberryPiTransmitPin* transmitPin = new RaspberryPiTransmitPin(nTransmitPin, nNonRealtimeOffset);
-
-    if(transmitPin->initialize() == 0){
-        delete transmitPin;
-        transmitPin = 0;
-    }
-
     return transmitPin;
 }
 #else

--- a/callforheat.cpp
+++ b/callforheat.cpp
@@ -6,7 +6,7 @@
 #include "Constants.h"
 
 int main(int argc, char *argv[]) {
-    int PIN = 0;
+    int PIN = 17;
 
     int callforheat = atoi(argv[1]);
 


### PR DESCRIPTION
Doing this as part of trying to get boilercontrol up and running on Raspberry Pi 2
Updated wiringPi to latest version which has changes

DO NOT MERGE: ensure that new Pi can be set up and running before merging this in order not to put existing boilercontrol on pi1 at risk.